### PR TITLE
Removing unused heroku references

### DIFF
--- a/providers.tf
+++ b/providers.tf
@@ -4,10 +4,6 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~>3.0"
     }
-    heroku = {
-      source  = "heroku/heroku"
-      version = "~>5.0"
-    }
   }
   cloud {
     organization = "hugodiniz"
@@ -16,11 +12,6 @@ terraform {
       name = "true-budget-infra"
     }
   }
-}
-
-provider "heroku" {
-  email   = var.heroku_username
-  api_key = var.heroku_api_key
 }
 
 provider "azurerm" {

--- a/variables.tf
+++ b/variables.tf
@@ -42,13 +42,3 @@ variable "tenant_id" {
   type      = string
   sensitive = true
 }
-
-variable "heroku_api_key" {
-  type      = string
-  sensitive = true
-}
-
-variable "heroku_username" {
-  type      = string
-  sensitive = true
-}


### PR DESCRIPTION
This PR removes all references of heroku from terraform files since we're not using it anymore